### PR TITLE
Removing loop cpu time adding to simulation time

### DIFF
--- a/sched/sched.c
+++ b/sched/sched.c
@@ -913,7 +913,8 @@ static void trigger_cb (flux_t *h,
     sched_loop = true;
     diff = clock () - start;
     seconds = ((double)diff) / CLOCKS_PER_SEC;
-    ctx->sctx.sim_state->sim_time += seconds;
+    // ctx->sctx.sim_state->sim_time += seconds;
+    // XXX: Maybe increment to account for an imaginary, but constant loop time
     if (sched_loop) {
         flux_log (h,
                   LOG_DEBUG,

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -210,9 +210,10 @@ int kvsdir_get_double (kvsdir_t *dir, const char *name, double *valp)
         goto done;
     rc = 0;
 done:
-    if (rc < 0)
-        flux_log_error (h, "pull_job_from_kvs: failed to get %s in %s",
-                        name, kvsdir_key (dir));
+    // FIXME: This is happening more than it should
+    // if (rc < 0)
+    //     flux_log_error (h, "pull_job_from_kvs: failed to get %s in %s",
+    //                     name, kvsdir_key (dir));
     free (key);
     flux_future_destroy (f);
     return rc;

--- a/simulator/submitsrv.c
+++ b/simulator/submitsrv.c
@@ -90,7 +90,7 @@ double convert_time_to_sec (char *time)
 }
 
 // Populate a field in the job_t based off a value extracted from the csv
-int insert_into_job (job_t *job, char *column_name, char *value)
+int insert_into_job (flux_t *h, job_t *job, char *column_name, char *value)
 {
     // Strip newline off the end, if it exists
     int last_char_index = strlen(column_name) - 1;
@@ -113,7 +113,27 @@ int insert_into_job (job_t *job, char *column_name, char *value)
     } else if (!strcmp (column_name, "Timelimit")) {
         job->time_limit = convert_time_to_sec (value);
     } else if (!strcmp (column_name, "Submit")) {
-        job->submit_time = atof (value);
+        char *endptr;
+        struct tm tm_spec; 
+        double stime = strtod(value, &endptr);
+        // Check if you parsed only a bit of the string (e.g. just the year)
+        // Trailing whitespace is not an error.
+        if (*endptr != '\0' && *endptr != ' ' && *endptr != '\t') {
+            endptr = strptime(value, "%Y-%m-%dT%H:%M:%S", &tm_spec);
+            if (endptr == NULL) {
+                endptr = value;
+            } else {
+                stime = (double) mktime(&tm_spec);
+            }
+        }
+        // endptr gets set by strtod or by strptime
+        if (endptr == value) {
+            flux_log (h, LOG_WARNING, "Incorrect Submit format, expects %s"
+                        " or seconds since epoch; replacing '%s' with %f",
+                        "%Y-%m-%dT%H:%M:%S (yyyy-mm-ddThh:mm:ss)",
+                        value, stime);
+        }
+        job->submit_time = stime;
     } else if (!strcmp (column_name, "Elapsed")) {
         job->execution_time = convert_time_to_sec (value);
     } else if (!strcmp (column_name, "IORate(MB)")) {
@@ -175,7 +195,7 @@ int parse_job_csv (flux_t *h, char *filename, zlist_t *jobs)
                 flux_log (h, LOG_ERR, "column name is NULL");
                 return -1;
             }
-            insert_into_job (curr_job, curr_column, token);
+            insert_into_job (h, curr_job, curr_column, token);
             token = strtok (NULL, ",");
             curr_column = zlist_next (header);
         }

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -50,7 +50,8 @@ TESTS = \
     t1005-sched-params.t \
     t2000-fcfs.t \
     t2001-fcfs-aware.t \
-    t2002-easy.t
+    t2002-easy.t \
+    t2003-fast_backfill.t
 
 check_SCRIPTS = $(TESTS)
 

--- a/t/t2003-fast_backfill.t
+++ b/t/t2003-fast_backfill.t
@@ -1,0 +1,51 @@
+#!/bin/sh
+#set -x
+
+test_description='Test fast_backfill scheduler in simulator
+'
+
+# source sharness from the directore where this test
+# file resides
+#
+. $(dirname $0)/sharness.sh
+
+rdlconf=$(sched_src_path "conf/hype-io.lua")
+jobdata=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/job-traces/hype-test.csv")
+expected_order=$(readlink -e "${SHARNESS_TEST_SRCDIR}/data/emulator-data/easy_expected")
+
+FLUX_MODULE_PATH_PREPEND="$FLUX_MODULE_PATH_PREPEND:$(sched_build_path simulator/.libs)"
+
+#
+# print only with --debug
+#
+test_debug '
+	echo rdlconf=${rdlconf} &&
+    echo jobdata=${jobdata} &&
+    echo expected_order=${expected_order}
+'
+
+#
+# test_under_flux is under sharness.d/
+#
+test_under_flux 1
+
+test_expect_success 'sim: started successfully' '
+    adjust_session_info 12 &&
+    timed_wait_job 5 &&
+    flux module load sim exit-on-complete=false &&
+    flux module load submit job-csv=${jobdata} &&
+    flux module load sim_exec &&
+    flux module load sched rdl-conf=${rdlconf} in-sim=true plugin=sched.fast_backfill plugin-opts=reserve-depth=1
+'
+
+test_expect_success 'sim: scheduled and ran all jobs' '
+    timed_sync_wait_job 60
+'
+
+for x in $(seq 1 12); do echo "$x $(flux kvs get $(job_kvs_path $x).starting_time)"; done | sort -k 2n -k 1n | cut -d ' ' -f 1 > actual
+
+test_expect_success 'jobs scheduled in correct order' '
+   diff -u ${expected_order} ./actual
+'
+
+test_done


### PR DESCRIPTION
Removing loop cpu time adding to simulation time This also slightly modifies the sim hackathon accounting for fast_backfill and removes the spurious errors 